### PR TITLE
support_oracle_linux

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -232,7 +232,8 @@ module MariaDBCookbook
     # build the platform string that makes up the final component of the yum repo URL
     def yum_repo_platform_string
       release = yum_releasever
-      "#{node['platform']}#{release}-#{node['kernel']['machine'] == 'x86_64' ? 'amd64' : '$basearch'}"
+      platform = platform?('oracle') ? 'centos' : node['platform']
+      "#{platform}#{release}-#{node['kernel']['machine'] == 'x86_64' ? 'amd64' : '$basearch'}"
     end
 
     # on amazon use the RHEL 6 packages. Otherwise use the releasever yum variable


### PR DESCRIPTION
why don't use yum repos for oracle-linux? Let's support this platform.

## Description

There is no support for oracle linux

### Issues Resolved

We will be able to install mariadb on oracle-linux platform.

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/mariadb/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
